### PR TITLE
Fix location of system.twmrc in FILES section of twm man page

### DIFF
--- a/man/twm.man
+++ b/man/twm.man
@@ -1263,7 +1263,7 @@ they may be lost if they are iconified and no bindings to
 .nf
 .I $HOME/.twmrc.<screen number>
 .I $HOME/.twmrc
-.I __projectroot__/lib/X11/twm/system.twmrc
+.I __datadir__/X11/twm/system.twmrc
 .fi
 .SH "ENVIRONMENT VARIABLES"
 .IP "DISPLAY" 8


### PR DESCRIPTION
In 76f6ad6e96b1ce62a32767bc0478a17b8b9204d7 the location of system.twmrc
in the manpage was fixed, but this didn't include its mention in the
FILES section.

This fixes this problem.

First reported here:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=246127